### PR TITLE
Change Elasticsearch host / Trigger CI

### DIFF
--- a/scripts/fetchChartForKeyword.sh
+++ b/scripts/fetchChartForKeyword.sh
@@ -4,4 +4,5 @@ mkdir -p ./src/chartData/
 keyword=`echo $1 | sed 's/\"/\\\"/g'`
 fname=$(( ( RANDOM % 100000 )  + 1 ))
 echo $keyword
+
 curl -XGET https://parlament-search.k-monitor.hu/parldata/_search/template\? -H "Content-Type: application/json" -d "{\"id\": \"filtered_query_v2\",\"params\": {\"q\": \"$keyword\"}}" | jq "{\"$keyword\": {\"aggregations\": {\"terms\": {\"buckets\": .aggregations.terms.buckets}}}}" > ./src/chartData/$fname.json


### PR DESCRIPTION
I accidentally pushed directly to master, which didn't trigger CI.
Sorry for messing up the commit/PR history!

The [original change](https://github.com/k-monitor/parliamentary_debates_open/commit/988f63b1b643a11206ba84a98979fd623cc2a13e) I wanted to make involves changing the Elasticsearch host from `parldata-search-proxy.westeurope.cloudapp.azure.com` to `parlament-search.k-monitor.hu` which is part of the migration process to a new azure VM.